### PR TITLE
:bug: fixed issue with icon text display

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(vendor/bin/pest:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/README.md
+++ b/README.md
@@ -121,10 +121,19 @@ The package comes with a configuration file that allows you to customize various
 
 ```php
 return [
+    // Path to breadcrumb definitions file (defaults to routes/breadcrumbs.php if null)
     'definitions_file' => base_path('routes/breadcrumbs.php'),
+
+    // Default view for rendering breadcrumbs
     'view' => 'breadcrumbs::breadcrumbs',
+
+    // Hide breadcrumbs when only one item exists
     'skip_single_item' => true,
+
+    // Separator character between breadcrumb items
     'separator' => '/',
+
+    // CSS classes for breadcrumb elements
     'classes' => [
         'wrapper' => 'breadcrumbs',
         'list' => 'breadcrumb-list',
@@ -133,6 +142,15 @@ return [
         'active' => 'breadcrumb-active',
         'separator' => 'breadcrumb-separator',
     ],
+
+    // The route name that represents home (e.g., 'dashboard', 'home', 'index')
+    'home_route' => 'dashboard',
+
+    // How to display the home breadcrumb: 'icon', 'text', or 'both'
+    'home_display' => 'icon',
+
+    // The FluxUI icon to use for home (e.g., 'house', 'home', 'squares-2x2')
+    'home_icon' => 'house',
 ];
 ```
 
@@ -185,18 +203,18 @@ Breadcrumbs::define('posts.show', function ($trail, $post) {
 });
 ```
 
-### Dashboard Icon Support
+### Home/Dashboard Icon Support
 
-The package includes special handling for Dashboard breadcrumbs:
+The package includes special handling for the home breadcrumb, which is configurable:
 
 ```php
-// When you define a breadcrumb with the title 'Dashboard'
+// Define your home breadcrumb (defaults to 'dashboard')
 Breadcrumbs::define('dashboard', function ($trail) {
     $trail->push('Dashboard', route('dashboard'));
 });
 ```
 
-It will automatically render with a house icon instead of text:
+By default, it renders with a house icon:
 
 ```blade
 <!-- Automatically renders as -->
@@ -204,6 +222,28 @@ It will automatically render with a house icon instead of text:
     <flux:icon icon="house" class="size-5 !text-orange-500 hover:!text-orange-600" />
 </flux:breadcrumbs.item>
 ```
+
+#### Customizing Home Display
+
+You can customize how the home breadcrumb appears using the configuration options:
+
+```php
+// config/breadcrumbs.php
+
+// Change which route is considered "home"
+'home_route' => 'home', // or 'dashboard', 'index', etc.
+
+// Control the display style
+'home_display' => 'icon',  // Options: 'icon', 'text', 'both'
+
+// Change the icon used
+'home_icon' => 'house',    // Options: 'house', 'home', 'squares-2x2', or any FluxUI icon
+```
+
+**Display Options:**
+- `'icon'` - Shows only the icon (default)
+- `'text'` - Shows only the text label
+- `'both'` - Shows both icon and text label
 
 ## Testing
 

--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -82,4 +82,43 @@ return [
     */
 
     'skip_single_item' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Home Route
+    |--------------------------------------------------------------------------
+    |
+    | The route name that represents the home/root page of your application.
+    | This route will be displayed with special styling and optionally with
+    | a house icon. Commonly set to 'dashboard', 'home', or 'index'.
+    |
+    */
+
+    'home_route' => 'dashboard',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Home Display Style
+    |--------------------------------------------------------------------------
+    |
+    | Controls how the home breadcrumb is displayed. Options:
+    | - 'icon' : Shows only the house icon
+    | - 'text' : Shows only the text label
+    | - 'both' : Shows both icon and text label
+    |
+    */
+
+    'home_display' => 'icon',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Home Icon
+    |--------------------------------------------------------------------------
+    |
+    | The icon to use for the home breadcrumb. This should be a valid
+    | FluxUI icon name. Common options: 'house', 'home', 'squares-2x2'
+    |
+    */
+
+    'home_icon' => 'house',
 ];

--- a/resources/views/breadcrumbs.blade.php
+++ b/resources/views/breadcrumbs.blade.php
@@ -1,12 +1,26 @@
+@php
+    $homeRoute = config('breadcrumbs.home_route', 'dashboard');
+    $homeDisplay = config('breadcrumbs.home_display', 'icon');
+    $homeIcon = config('breadcrumbs.home_icon', 'house');
+@endphp
+
 @if (count($breadcrumbs) > 0)
     <div {{ $attributes->merge(['class' => 'mt-1 flex items-center']) }}>
         <flux:breadcrumbs class="text-sm font-medium sm:text-lg">
             @foreach ($breadcrumbs as $breadcrumb)
+                @php
+                    $isHome = $breadcrumb->title === ucfirst($homeRoute) && $loop->first;
+                @endphp
+
                 @if ($breadcrumb->url && !$loop->last)
-                    @if ($breadcrumb->title === 'Dashboard' && $loop->first)
+                    @if ($isHome)
                         <flux:breadcrumbs.item href="{{ $breadcrumb->url }}">
-                            <flux:icon icon="house" class="size-5 !text-orange-500 hover:!text-orange-600" />
-                            {{ $breadcrumb->title }}
+                            @if (in_array($homeDisplay, ['icon', 'both']))
+                                <flux:icon icon="{{ $homeIcon }}" class="size-5 !text-orange-500 hover:!text-orange-600" />
+                            @endif
+                            @if (in_array($homeDisplay, ['text', 'both']))
+                                {{ $breadcrumb->title }}
+                            @endif
                         </flux:breadcrumbs.item>
                     @else
                         <flux:breadcrumbs.item
@@ -17,10 +31,14 @@
                         </flux:breadcrumbs.item>
                     @endif
                 @else
-                    @if ($breadcrumb->title === 'Dashboard' && $loop->first)
+                    @if ($isHome)
                         <flux:breadcrumbs.item class="!text-orange-500">
-                            <flux:icon icon="house" class="size-5" />
-                            {{ $breadcrumb->title }}
+                            @if (in_array($homeDisplay, ['icon', 'both']))
+                                <flux:icon icon="{{ $homeIcon }}" class="size-5" />
+                            @endif
+                            @if (in_array($homeDisplay, ['text', 'both']))
+                                {{ $breadcrumb->title }}
+                            @endif
                         </flux:breadcrumbs.item>
                     @else
                         <flux:breadcrumbs.item class="!text-sm !text-zinc-400 sm:!text-lg dark:!text-zinc-500">

--- a/tests/Feature/BreadcrumbsComponentTest.php
+++ b/tests/Feature/BreadcrumbsComponentTest.php
@@ -22,7 +22,7 @@ it('renders breadcrumbs component', function () {
 
     $view = $this->blade('<x-breadcrumbs route="users.index" />');
 
-    $view->assertSee('Dashboard');
+    $view->assertSee('house'); // Should see the house icon for Dashboard
     $view->assertSee('Users');
     $view->assertSee('flux:breadcrumbs');
 });
@@ -94,4 +94,93 @@ it('renders multiple breadcrumbs with flux components', function () {
     $view->assertSee('flux:breadcrumbs.item');
     $view->assertSee('house');
     $view->assertSee('John Doe');
+});
+
+it('respects home_display config set to text', function () {
+    config(['breadcrumbs.home_display' => 'text']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('dashboard', function ($trail) {
+        $trail->push('Dashboard', '/dashboard');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="dashboard" />');
+
+    $view->assertSee('Dashboard');
+    $view->assertDontSee('flux:icon');
+});
+
+it('respects home_display config set to both', function () {
+    config(['breadcrumbs.home_display' => 'both']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('dashboard', function ($trail) {
+        $trail->push('Dashboard', '/dashboard');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="dashboard" />');
+
+    $view->assertSee('Dashboard');
+    $view->assertSee('flux:icon');
+    $view->assertSee('house');
+});
+
+it('respects home_display config set to icon', function () {
+    config(['breadcrumbs.home_display' => 'icon']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('dashboard', function ($trail) {
+        $trail->push('Dashboard', '/dashboard');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="dashboard" />');
+
+    $view->assertSee('flux:icon');
+    $view->assertSee('house');
+    $view->assertDontSee('Dashboard');
+});
+
+it('respects custom home_icon config', function () {
+    config(['breadcrumbs.home_icon' => 'home']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('dashboard', function ($trail) {
+        $trail->push('Dashboard', '/dashboard');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="dashboard" />');
+
+    $view->assertSee('flux:icon');
+    $view->assertSee('home');
+    $view->assertDontSee('house');
+});
+
+it('respects custom home_route config', function () {
+    config(['breadcrumbs.home_route' => 'home']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('home', function ($trail) {
+        $trail->push('Home', '/home');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="home" />');
+
+    $view->assertSee('flux:icon');
+    $view->assertSee('house');
+    $view->assertSee('text-orange-500');
+});
+
+it('does not apply home styling to non-home routes', function () {
+    config(['breadcrumbs.home_route' => 'dashboard']);
+    config(['breadcrumbs.skip_single_item' => false]);
+
+    Breadcrumbs::define('about', function ($trail) {
+        $trail->push('About', '/about');
+    });
+
+    $view = $this->blade('<x-breadcrumbs route="about" />');
+
+    $view->assertDontSee('flux:icon');
+    $view->assertDontSee('house');
+    $view->assertSee('About');
 });


### PR DESCRIPTION
This pull request adds configurable support for customizing the appearance and behavior of the "home" breadcrumb (typically "Dashboard" or "Home") in the breadcrumbs component. It introduces new configuration options, updates the Blade view logic to respect these settings, improves documentation, and adds comprehensive tests to verify the new functionality.

**Home breadcrumb customization:**

* Added new configuration options in `config/breadcrumbs.php` for `home_route`, `home_display`, and `home_icon`, allowing developers to control which route is considered "home," how it is displayed (icon, text, or both), and which icon is used.
* Updated `resources/views/breadcrumbs.blade.php` to use the new config options when rendering the home breadcrumb, conditionally showing the icon, text, or both, and applying special styling only to the configured home route. [[1]](diffhunk://#diff-6e8886d741eb17d27dd2f91333674e5c9ce495cb76c05729e56548e250d5c89fR1-R23) [[2]](diffhunk://#diff-6e8886d741eb17d27dd2f91333674e5c9ce495cb76c05729e56548e250d5c89fL20-R41)

**Documentation improvements:**

* Expanded the `README.md` to document the new configuration options, explain how to customize the home breadcrumb, and clarify display options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124-R136) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R145-R153) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L188-R217) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R226-R247)

**Testing:**

* Added new feature tests in `tests/Feature/BreadcrumbsComponentTest.php` to verify that the home breadcrumb respects the new configuration for route, display style, and icon, and does not apply home styling to non-home routes. [[1]](diffhunk://#diff-1e41a4d9fd18771a023bc0cfcd0b417f2ad3226fa82500b14851d802ac31b108L25-R25) [[2]](diffhunk://#diff-1e41a4d9fd18771a023bc0cfcd0b417f2ad3226fa82500b14851d802ac31b108R98-R186)

**Miscellaneous:**

* Added a local settings file `.claude/settings.local.json` to allow Pest test execution.